### PR TITLE
Beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "roadrunner-php/symfony-lock-driver",
   "type": "library",
-  "description": "RoadRunner: HTTP and PSR-7 worker",
+  "description": "RoadRunner: symfony/lock bridge",
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "spiral/symfony-lock-driver",
+  "name": "roadrunner-php/symfony-lock-driver",
   "type": "library",
   "description": "RoadRunner: HTTP and PSR-7 worker",
   "license": "MIT",

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -24,6 +24,8 @@ final class RoadRunnerStore implements SharedLockStoreInterface
         private readonly float           $initialTtl = 300.0,
         private readonly float           $initialWaitTtl = 0,
     ) {
+        \assert($this->initialTtl >= 0);
+        \assert($this->initialWaitTtl >= 0);
     }
 
     public function save(Key $key): void

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Symfony\Lock;
 
-use RoadRunner\Lock\LockInterface as RrLockInterface;
+use RoadRunner\Lock as RR;
 use Spiral\Goridge\RPC\Exception\RPCException;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
@@ -14,10 +14,15 @@ use Symfony\Component\Lock\SharedLockStoreInterface;
 
 final class RoadRunnerStore implements SharedLockStoreInterface
 {
+    /**
+     * @param RR\LockInterface $rrLock
+     * @param float $initialTtl The time-to-live of the lock, in seconds. Defaults to 0 (forever).
+     * @param float $initialWaitTtl How long to wait to acquire lock until returning false.
+     */
     public function __construct(
-        private readonly RrLockInterface $rrLock,
-        private float $initialTtl = 300.0,
-        private float $initialWaitTtl = 0,
+        private readonly RR\LockInterface $rrLock,
+        private readonly float           $initialTtl = 300.0,
+        private readonly float           $initialWaitTtl = 0,
     ) {
     }
 

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -16,6 +16,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
 {
     public function __construct(
         private readonly RrLockInterface $rrLock,
+        private float $initialTtl = 300.0,
     ) {
     }
 
@@ -23,7 +24,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
     {
         \assert(false === $key->hasState(__CLASS__));
         try {
-            $lockId = $this->rrLock->lock((string) $key);
+            $lockId = $this->rrLock->lock((string) $key, null, $this->initialTtl);
             if (false === $lockId) {
                 throw new LockConflictedException('RoadRunner. Failed to make lock');
             }
@@ -36,7 +37,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
     public function saveRead(Key $key): void
     {
         \assert(false === $key->hasState(__CLASS__));
-        $lockId = $this->rrLock->lockRead((string)$key);
+        $lockId = $this->rrLock->lockRead((string)$key, null, $this->initialTtl);
         if (false === $lockId) {
             throw new LockConflictedException('RoadRunner. Failed to make read lock');
         }

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -17,6 +17,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
     public function __construct(
         private readonly RrLockInterface $rrLock,
         private float $initialTtl = 300.0,
+        private float $initialWaitTtl = 0,
     ) {
     }
 
@@ -24,7 +25,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
     {
         \assert(false === $key->hasState(__CLASS__));
         try {
-            $lockId = $this->rrLock->lock((string) $key, null, $this->initialTtl);
+            $lockId = $this->rrLock->lock((string) $key, null, $this->initialTtl, $this->initialWaitTtl);
             if (false === $lockId) {
                 throw new LockConflictedException('RoadRunner. Failed to make lock');
             }
@@ -37,7 +38,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
     public function saveRead(Key $key): void
     {
         \assert(false === $key->hasState(__CLASS__));
-        $lockId = $this->rrLock->lockRead((string)$key, null, $this->initialTtl);
+        $lockId = $this->rrLock->lockRead((string)$key, null, $this->initialTtl, $this->initialWaitTtl);
         if (false === $lockId) {
             throw new LockConflictedException('RoadRunner. Failed to make read lock');
         }

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -61,6 +61,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface
     public function putOffExpiration(Key $key, float $ttl): void
     {
         \assert($key->hasState(__CLASS__));
+        \assert($ttl > 0);
         if (false === $this->rrLock->updateTTL((string) $key, $key->getState(__CLASS__), $ttl)) {
             throw new LockConflictedException('RoadRunner. Failed to update lock ttl');
         }

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -5,43 +5,56 @@ declare(strict_types=1);
 namespace Spiral\RoadRunner\Symfony\Lock;
 
 use RoadRunner\Lock\LockInterface as RrLockInterface;
+use Spiral\Goridge\RPC\Exception\RPCException;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\Key;
-use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\SharedLockStoreInterface;
 
 final class RoadRunnerStore implements SharedLockStoreInterface
 {
-    private string $processId;
-
     public function __construct(
         private readonly RrLockInterface $rrLock,
-        ?string $processId = null
+        private readonly string          $processId
     ) {
-        $this->processId = $processId ?? '*';
     }
 
     public function save(Key $key): void
     {
-        $this->rrLock->lock((string) $key, $this->processId);
-    }
-
-    public function exists(Key $key): bool
-    {
-        return $this->rrLock->exists((string) $key, $this->processId);
-    }
-
-    public function putOffExpiration(Key $key, float $ttl): void
-    {
-        $this->rrLock->updateTTL((string) $key, $this->processId, $ttl);
-    }
-
-    public function delete(Key $key): void
-    {
-        $this->rrLock->release((string) $key, $this->processId);
+        try {
+            $lockId = $this->rrLock->lock((string)$key);
+            if (false === $lockId) {
+                throw new LockConflictedException('RoadRunner. Failed to make lock');
+            }
+        } catch (RPCException $e) {
+            throw new LockAcquiringException(message: 'RoadRunner. RPC call error', previous: $e);
+        }
     }
 
     public function saveRead(Key $key): void
     {
-        $this->rrLock->lockRead((string) $key, $this->processId);
+        if (false === $this->rrLock->lockRead((string)$key)) {
+            throw new LockConflictedException('RoadRunner. Failed to make read lock');
+        }
+    }
+
+    public function exists(Key $key): bool
+    {
+        return $this->rrLock->exists((string)$key, $this->processId);
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
+    {
+        if (false === $this->rrLock->updateTTL((string)$key, $this->processId, $ttl)) {
+            throw new LockConflictedException('RoadRunner. Failed to update lock ttl');
+        }
+    }
+
+    public function delete(Key $key): void
+    {
+        if (false === $this->rrLock->release((string)$key, $this->processId)) {
+            throw new LockReleasingException('RoadRunner. Failed to release lock');
+        }
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Spiral\RoadRunner\Symfony\Lock\Tests;
 
 use PHPUnit\Framework\TestCase;
-use RoadRunner\Lock\LockInterface as RrLock;
+use RoadRunner\Lock as RR;
 use Spiral\RoadRunner\Symfony\Lock\RoadRunnerStore;
 use Symfony\Component\Lock\LockFactory;
 
@@ -20,7 +20,7 @@ final class IntegrationTest extends TestCase
                 'uuid2'
             ],
         ];
-        $rrLock = $this->createMock(RrLock::class);
+        $rrLock = $this->createMock(RR\LockInterface::class);
         $rrLock
             ->expects(self::exactly(3))
             ->method('lock')

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Symfony\Lock\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RoadRunner\Lock\LockInterface as RrLock;
+use Spiral\RoadRunner\Symfony\Lock\RoadRunnerStore;
+use Symfony\Component\Lock\LockFactory;
+
+final class IntegrationTest extends TestCase
+{
+    public function testLock(): void
+    {
+        $responseList = [
+            'test-lock' => [
+                'uuid1',
+                false,
+                'uuid2'
+            ],
+        ];
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock
+            ->expects(self::exactly(3))
+            ->method('lock')
+            ->willReturnCallback(function (string $name) use (&$responseList) {
+                $array_shift = \array_shift($responseList[$name]);
+                return $array_shift;
+            });
+        $rrLock
+            ->expects(self::exactly(2))
+            ->method('updateTTL')
+            ->willReturn(true);
+
+        $rrLock
+            ->expects(self::exactly(2))
+            ->method('release')
+            ->willReturn(true);
+
+        // lock
+        $factory = new LockFactory(new RoadRunnerStore($rrLock));
+        $lock1 = $factory->createLock('test-lock');
+        self::assertTrue($lock1->acquire());
+
+        $lock2 = $factory->createLock('test-lock');
+        self::assertFalse($lock2->acquire());
+
+        $lock1->release();
+
+        // lock 2
+        self::assertTrue($lock2->acquire());
+        $lock2->release();
+    }
+}

--- a/tests/RoadRunnerStoreTest.php
+++ b/tests/RoadRunnerStoreTest.php
@@ -7,57 +7,133 @@ namespace Spiral\RoadRunner\Symfony\Lock\Tests;
 use PHPUnit\Framework\TestCase;
 use RoadRunner\Lock\LockInterface as RrLock;
 use Spiral\RoadRunner\Symfony\Lock\RoadRunnerStore;
+
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockReleasingException;
 use Symfony\Component\Lock\Key;
 
 final class RoadRunnerStoreTest extends TestCase
 {
-    public function testSave(): void
+    public function testSaveSuccess(): void
     {
         $rrLock = $this->createMock(RrLock::class);
         $rrLock->expects(self::once())
             ->method('lock')
-            ->with('resource-name', '*');
-        $store = new RoadRunnerStore($rrLock);
+            ->with('resource-name', null)
+            ->willReturn('lock-id');
+        $store = new RoadRunnerStore($rrLock, 'pid');
         $store->save(new Key('resource-name'));
     }
 
-    public function testExists(): void
-    {
-        $rrLock = $this->createMock(RrLock::class);
-        $rrLock->expects(self::once())
-            ->method('exists')
-            ->with('resource-name', '*');
-        $store = new RoadRunnerStore($rrLock);
-        $store->exists(new Key('resource-name'));
-    }
-
-    public function testPutOffExpiration(): void
-    {
-        $rrLock = $this->createMock(RrLock::class);
-        $rrLock->expects(self::once())
-            ->method('updateTTL')
-            ->with('resource-name', '*', 3600.0);
-        $store = new RoadRunnerStore($rrLock);
-        $store->putOffExpiration(new Key('resource-name'), 3600.0);
-    }
-
-    public function testDelete(): void
-    {
-        $rrLock = $this->createMock(RrLock::class);
-        $rrLock->expects(self::once())
-            ->method('release')
-            ->with('resource-name', '*');
-        $store = new RoadRunnerStore($rrLock);
-        $store->delete(new Key('resource-name'));
-    }
-
-    public function testSaveRead(): void
+    public function testSaveReadSuccess(): void
     {
         $rrLock = $this->createMock(RrLock::class);
         $rrLock->expects(self::once())
             ->method('lockRead')
-            ->with('resource-name', '*');
-        $store = new RoadRunnerStore($rrLock);
+            ->with('resource-name', null)
+            ->willReturn('lock-id');
+        $store = new RoadRunnerStore($rrLock, 'pid');
         $store->saveRead(new Key('resource-name'));
+    }
+
+    public function testExistsSuccess(): void
+    {
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('exists')
+            ->with('resource-name', 'pid')
+            ->willReturn(true);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->exists(new Key('resource-name'));
+    }
+
+    public function testPutOffExpirationSuccess(): void
+    {
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('updateTTL')
+            ->with('resource-name', 'pid', 3600.0)
+            ->willReturn(true);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->putOffExpiration(new Key('resource-name'), 3600.0);
+    }
+
+    public function testDeleteSuccess(): void
+    {
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('release')
+            ->with('resource-name', 'pid')
+            ->willReturn(true);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->delete(new Key('resource-name'));
+    }
+
+    public function testSaveFail(): void
+    {
+        self::expectException(LockConflictedException::class);
+        self::expectExceptionMessage('RoadRunner. Failed to make lock');
+
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('lock')
+            ->with('resource-name', null)
+            ->willReturn(false);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->save(new Key('resource-name'));
+    }
+
+    public function testSaveReadFail(): void
+    {
+        self::expectException(LockConflictedException::class);
+        self::expectExceptionMessage('RoadRunner. Failed to make read lock');
+
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('lockRead')
+            ->with('resource-name', null);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->saveRead(new Key('resource-name'));
+    }
+
+    public function testExistsFail(): void
+    {
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('exists')
+            ->with('resource-name', 'pid')
+            ->willReturn(false);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        self::assertFalse(
+            $store->exists(new Key('resource-name'))
+        );
+    }
+
+    public function testPutOffExpirationFail(): void
+    {
+        self::expectException(LockConflictedException::class);
+        self::expectExceptionMessage('RoadRunner. Failed to update lock ttl');
+
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('updateTTL')
+            ->with('resource-name', 'pid', 3600.0)
+            ->willReturn(false);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->putOffExpiration(new Key('resource-name'), 3600.0);
+    }
+
+    public function testDeleteFail(): void
+    {
+        self::expectException(LockReleasingException::class);
+        self::expectExceptionMessage('RoadRunner. Failed to release lock');
+
+        $rrLock = $this->createMock(RrLock::class);
+        $rrLock->expects(self::once())
+            ->method('release')
+            ->with('resource-name', 'pid')
+            ->willReturn(false);
+        $store = new RoadRunnerStore($rrLock, 'pid');
+        $store->delete(new Key('resource-name'));
     }
 }


### PR DESCRIPTION
Simple bootloader example
```php
final class LockBootloader extends Bootloader
{
    public function defineSingletons(): array
    {
        return [
            RR\LockInterface::class => RR\Lock::class,
            LockFactory::class => LockFactory::class,
            PersistingStoreInterface::class => static fn (RR\LockInterface $rrLock) => new RoadRunnerStore($rrLock),
        ];
    }
}
```

Tests code example

```php
$key = 'test-lock';

$lock1 = $factory->createLock($key);
$res1 = $lock1->acquire();
$output->writeln('Lock 1 acquire: '.(int) $res1);

$lock2 = $factory->createLock($key);
$res2 = $lock2->acquire();
$output->writeln('Lock 2 acquire: '.(int) $res2);

$output->writeln('Lock 1 release');
$lock1->release();
sleep(1);

$lock2 = $factory->createLock($key);
$res2 = $lock2->acquire();
$output->writeln('Lock 2 acquire: '.(int) $res2);

$lock2->release();
$output->writeln('Lock 2 release');
```

rr output
```
// $lock1->acquire()

DEBUG   lock   lock request received   {"ttl": 10000000, "wait_ttl": 0, "resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   acquiring lock, w==0, r==0      {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   updateTTL request received      {"ttl": 300000000, "wait_ttl": 0, "resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   updateTTL started       {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   lock/rlocl TTL was successfully updated {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   updating r/lock ttl     {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f", "new_ttl_microsec": 300000000}


// $lock2->acquire()

DEBUG   lock   lock request received   {"ttl": 10000000, "wait_ttl": 0, "resource": "test-lock", "id": "c0b24099-d2a5-4d98-b7fa-d3233ae7876d"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "c0b24099-d2a5-4d98-b7fa-d3233ae7876d"}
DEBUG   lock   waiting to hold the mutex       {"id": "c0b24099-d2a5-4d98-b7fa-d3233ae7876d"}
DEBUG   lock   returning releaseMuCh mutex to temporarily allow releasing locks        {"resource": "test-lock", "id": "c0b24099-d2a5-4d98-b7fa-d3233ae7876d"}
WARN    lock   lock notification wait timeout expired  {"id": "c0b24099-d2a5-4d98-b7fa-d3233ae7876d"}
DEBUG   lock   releaseMuCh lock not returned, channel is full  {"resource": "test-lock", "id": "c0b24099-d2a5-4d98-b7fa-d3233ae7876d"}


// $lock1->release()

DEBUG   lock   release request received        {"ttl": 0, "wait_ttl": 0, "resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   acquired release mutex  {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   lock successfully released      {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   r/lock: ttl removed, callback call      {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f", "ttl microseconds": 10000000}
DEBUG   lock   current writers and readers count       {"writers": 0, "readers": 0, "resource": "test-lock", "deleted id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   deleting the last lock, sending notification    {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   'exists' request received       {"ttl": 0, "wait_ttl": 0, "resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
WARN    lock   no such lock ID {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "f1b7674c-260f-436f-a04c-b75a1f9b881f"}


// $lock2->acquire()

DEBUG   lock   lock request received   {"ttl": 10000000, "wait_ttl": 0, "resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   acquiring lock, w==0, r==0      {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   updateTTL request received      {"ttl": 300000000, "wait_ttl": 0, "resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   updateTTL started       {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   lock/rlocl TTL was successfully updated {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   updating r/lock ttl     {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab", "new_ttl_microsec": 300000000}


// $lock2->release()

DEBUG   lock   release request received        {"ttl": 0, "wait_ttl": 0, "resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   acquired release mutex  {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   lock successfully released      {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   r/lock: ttl removed, callback call      {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab", "ttl microseconds": 10000000}
DEBUG   lock   current writers and readers count       {"writers": 0, "readers": 0, "resource": "test-lock", "deleted id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   deleting the last lock, sending notification    {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   'exists' request received       {"ttl": 0, "wait_ttl": 0, "resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   acquired muCh and releaseMuCh mutexes   {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
WARN    lock   no such lock ID {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
DEBUG   lock   releaseMuCh lock returned       {"resource": "test-lock", "id": "9941bb50-b73c-40fe-8a9a-b8ec4c43d6ab"}
```