### PR TITLE
Set initialWaitTtl = 0; add $waitTtl param to withTtl()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "vimeo/psalm": "^5.9"
+        "vimeo/psalm": "^5.9 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "require": {
         "php": ">=8.1",
         "roadrunner-php/lock": "^1.0",
-        "symfony/lock": "^6.0 || ^7.0"
+        "symfony/lock": "^6.0 || ^7.0",
+        "symfony/polyfill": "^1.32"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=8.1",
         "roadrunner-php/lock": "^1.0",
         "symfony/lock": "^6.0 || ^7.0",
-        "symfony/polyfill": "^1.32"
+        "symfony/polyfill-php83": "^1.32"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",

--- a/src/RandomTokenGenerator.php
+++ b/src/RandomTokenGenerator.php
@@ -14,6 +14,7 @@ final class RandomTokenGenerator implements TokenGeneratorInterface
     ) {
     }
 
+    #[\Override]
     public function generate(): string
     {
         return \bin2hex(\random_bytes($this->length));

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -36,6 +36,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         return new self($this->lock, $this->tokens, $ttl, $waitTtl);
     }
 
+    #[\Override]
     public function save(Key $key): void
     {
         \assert(false === $key->hasState(__CLASS__));
@@ -58,6 +59,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         }
     }
 
+    #[\Override]
     public function saveRead(Key $key): void
     {
         \assert(false === $key->hasState(__CLASS__));
@@ -74,6 +76,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         $key->setState(__CLASS__, $lockId);
     }
 
+    #[\Override]
     public function exists(Key $key): bool
     {
         \assert($key->hasState(__CLASS__));
@@ -86,6 +89,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         return $this->lock->exists($resource, $lockId);
     }
 
+    #[\Override]
     public function putOffExpiration(Key $key, float $ttl): void
     {
         \assert($key->hasState(__CLASS__));
@@ -101,6 +105,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         }
     }
 
+    #[\Override]
     public function delete(Key $key): void
     {
         \assert($key->hasState(__CLASS__));
@@ -111,6 +116,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         $this->lock->release($resource, $lockId);
     }
 
+    #[\Override]
     public function waitAndSave(Key $key): void
     {
         $lockId = $this->getUniqueToken($key);

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -25,15 +25,15 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         private readonly RR\LockInterface $lock,
         private readonly TokenGeneratorInterface $tokens = new RandomTokenGenerator(),
         private readonly float $initialTtl = 300.0,
-        private readonly float $initialWaitTtl = 60,
+        private readonly float $initialWaitTtl = 0,
     ) {
         \assert($this->initialTtl >= 0);
         \assert($this->initialWaitTtl >= 0);
     }
 
-    public function withTtl(float $ttl): self
+    public function withTtl(float $ttl, float $waitTtl = 0): self
     {
-        return new self($this->lock, $this->tokens, $ttl, $this->initialWaitTtl);
+        return new self($this->lock, $this->tokens, $ttl, $waitTtl);
     }
 
     public function save(Key $key): void
@@ -46,7 +46,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
             /** @var non-empty-string $resource */
             $resource = (string)$key;
 
-            $status = $this->lock->lock($resource, $lockId, $this->initialTtl);
+            $status = $this->lock->lock($resource, $lockId, $this->initialTtl, $this->initialWaitTtl);
 
             if (false === $status) {
                 throw new LockConflictedException('RoadRunner. Failed to make lock');
@@ -65,7 +65,7 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
 
         /** @var non-empty-string $resource */
         $resource = (string)$key;
-        $status = $this->lock->lockRead($resource, $lockId, $this->initialTtl);
+        $status = $this->lock->lockRead($resource, $lockId, $this->initialTtl, $this->initialWaitTtl);
 
         if (false === $status) {
             throw new LockConflictedException('RoadRunner. Failed to make read lock');

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -31,8 +31,12 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
         \assert($this->initialWaitTtl >= 0);
     }
 
-    public function withTtl(float $ttl, float $waitTtl = 0): self
+    /**
+     * Clone current instance with another values of ttl.
+     */
+    public function withTtl(float $ttl, ?float $waitTtl = null): self
     {
+        $waitTtl ??= $this->initialWaitTtl;
         return new self($this->lock, $this->tokens, $ttl, $waitTtl);
     }
 

--- a/src/RoadRunnerStore.php
+++ b/src/RoadRunnerStore.php
@@ -33,6 +33,8 @@ final class RoadRunnerStore implements SharedLockStoreInterface, BlockingStoreIn
 
     /**
      * Clone current instance with another values of ttl.
+     * @param float $ttl The time-to-live of the lock, in seconds. Defaults to 0 (forever).
+     * @param float $waitTtl How long to wait to acquire lock until returning false, in seconds.
      */
     public function withTtl(float $ttl, ?float $waitTtl = null): self
     {

--- a/tests/RoadRunnerStoreTest.php
+++ b/tests/RoadRunnerStoreTest.php
@@ -166,7 +166,7 @@ final class RoadRunnerStoreTest extends TestCase
     {
         $this->rrLock->expects($this->once())
             ->method('lock')
-            ->with('resource-name', 'random-id', 300, 60)
+            ->with('resource-name', 'random-id', 300, 0)
             ->willReturn('lock-id');
 
         $store = new RoadRunnerStore($this->rrLock, $this->tokens);
@@ -184,7 +184,7 @@ final class RoadRunnerStoreTest extends TestCase
 
         $this->rrLock->expects($this->once())
             ->method('lock')
-            ->with('resource-name', 'random-id', 300, 60)
+            ->with('resource-name', 'random-id', 300, 0)
             ->willReturn(false);
 
         $store = new RoadRunnerStore($this->rrLock, $this->tokens);

--- a/tests/RoadRunnerStoreTest.php
+++ b/tests/RoadRunnerStoreTest.php
@@ -190,4 +190,45 @@ final class RoadRunnerStoreTest extends TestCase
         $store = new RoadRunnerStore($this->rrLock, $this->tokens);
         $store->waitAndSave(new Key('resource-name'));
     }
+
+    /**
+     * @dataProvider dataWithTtl
+     */
+    public function testWithTtl(float $ttl, ?float $waitTtl, float $ttlExp, float $waitTtlExp): void
+    {
+        $this->rrLock->expects($this->once())
+            ->method('lock')
+            ->with('resource-name', 'random-id', $ttlExp, $waitTtlExp)
+            ->willReturn('lock-id');
+
+        $s = new RoadRunnerStore($this->rrLock, $this->tokens);
+        $s->withTtl($ttl, $waitTtl)->save(new Key('resource-name'));
+    }
+
+    /**
+     * @return iterable
+     */
+    public static function dataWithTtl(): iterable
+    {
+        yield [
+            100,
+            null,
+            100,
+            0,
+        ];
+
+        yield [
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+        ];
+
+        yield [
+            0,
+            0,
+            0,
+            0,
+        ];
+    }
 }


### PR DESCRIPTION
Also use `initialWaitTtl` while lock creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated default timing behavior in token storage and locking mechanisms for improved flexibility.
  - Enhanced compatibility with newer versions of a development tool.
  - Added override attributes to clarify method implementations.
- **Tests**
  - Adjusted test cases to align with updated locking behavior and timing defaults.
  - Added parameterized tests to verify timing configurations in token storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->